### PR TITLE
Corrected settings files.

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]   
+STRING:downwardheuristic=[ff(), cea()] 
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsFast.ini
+++ b/settingsFast.ini
@@ -15,7 +15,7 @@ LIST<STRING>:reformulator=walker,sameoutput
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]   
+STRING:downwardheuristic=[ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsLab.ini
+++ b/settingsLab.ini
@@ -16,7 +16,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]  
+STRING:downwardheuristic=[ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsLabMultiple.ini
+++ b/settingsLabMultiple.ini
@@ -16,7 +16,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]  
+STRING:downwardheuristic=[ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsStress.ini
+++ b/settingsStress.ini
@@ -17,7 +17,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]  
+STRING:downwardheuristic=[ff(), cea()]  
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator
@@ -25,7 +25,7 @@ STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
     ; goalCount - The walker choses actions that increase the number of goal facts in the state, otherwise random
     ; goalPredicateCount - The walker choses actions that increase the number of goal facts in the state, or facts relating to the goal, otherwise random
 STRING:heuristic=goalPredicateCount
-INT:timelimit=1000
+INT:timelimit=10000
 BOOL:printwalkersteps=false
 
 ; == Entanglement Finder Settings ==


### PR DESCRIPTION
Lab can parse with `lazy_greedy` and [ff(), cea()], [ff(), cea()]. Lab does not use the downwardheuristics
It is the SingleSearchParser that reports the unexplained error of 
['multiple initial h values found for cea', 'multiple initial h values found for ff']
from downwardLog because there are multiple initializations
[t=0.0056703s, 10928 KB] Initial heuristic value for ff: 21
[t=0.0057166s, 10928 KB] Initial heuristic value for cea: 30
[t=0.0057435s, 10928 KB] Initial heuristic value for cea: 30
[t=0.0057603s, 10928 KB] Initial heuristic value for ff: 21

Still with this error the solution is found.