### PR TITLE
Fixed configs

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()] 
+STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsFast.ini
+++ b/settingsFast.ini
@@ -15,7 +15,7 @@ LIST<STRING>:reformulator=walker,sameoutput
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()]
+STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsLab.ini
+++ b/settingsLab.ini
@@ -16,7 +16,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()]
+STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsLabMultiple.ini
+++ b/settingsLabMultiple.ini
@@ -16,7 +16,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()]
+STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator

--- a/settingsStress.ini
+++ b/settingsStress.ini
@@ -17,7 +17,7 @@ LIST<STRING>:reformulator=walker
 
 ; == Fast Downward Settings ==
 STRING:downwardsearch=lazy_greedy
-STRING:downwardheuristic=[ff(), cea()]  
+STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
 
 ; == Walker Settings ==
 ; Heuristics - Only relevant to the walker reformulator


### PR DESCRIPTION
Changing `STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]` to `STRING:downwardheuristic=[ff(), cea()]` seems to make downward **significantly** slower for some reason.
So i added it back to the configs again.