### PR TITLE
Fixes

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -42,6 +42,7 @@ STRING:levelReductionTypes=Division
 
 ; == Entanglement Evaluator Settings ==
 DOUBLE:minimumQualityPercent=0.50
+INT:maxCandidates=100
 ; EntanglerLengthModifier - What modifier to give to the Quality of occurance length
     ; none - 1
     ; default - Length / MaxLength

--- a/settings.ini
+++ b/settings.ini
@@ -12,8 +12,8 @@ PATH:validatorpath=../../P7Requirements/downward/VAL/validate
 INT:startIncrement=1
 ; incrementModifier - By how much the previous increment time limit should be multiplied with
 INT:incrementModifier=3
-; Maximum time that an increment can have. If this is exceeded, the program stops.
-INT:incrementLimit=120
+; Maximum time (in seconds) the execution of a reformulator can take in total
+INT:totalTimeLimit=120
 ; Reformulators
     ; sameoutput - Does nothing
     ; walker - Generates macros based on walks through the state space

--- a/settingsFast.ini
+++ b/settingsFast.ini
@@ -28,7 +28,7 @@ STRING:downwardheuristic=[ff(), cea()], [ff(), cea()]
     ; random - The walker choses actions at random
     ; goalCount - The walker choses actions that increase the number of goal facts in the state, otherwise random
     ; goalPredicateCount - The walker choses actions that increase the number of goal facts in the state, or facts relating to the goal, otherwise random
-STRING:heuristic=goalPredicateCount
+STRING:heuristic=random
 BOOL:printwalkersteps=false
 
 ; == Entanglement Finder Settings ==
@@ -42,6 +42,7 @@ STRING:levelReductionTypes=Division
 
 ; == Entanglement Evaluator Settings ==
 DOUBLE:minimumQualityPercent=0.50
+INT:maxCandidates=100
 ; EntanglerLengthModifier - What modifier to give to the Quality of occurance length
     ; none - 1
     ; default - Length / MaxLength

--- a/settingsFast.ini
+++ b/settingsFast.ini
@@ -12,8 +12,8 @@ PATH:validatorpath=../../P7Requirements/downward/VAL/validate
 INT:startIncrement=1
 ; incrementModifier - By how much the previous increment time limit should be multiplied with
 INT:incrementModifier=3
-; Maximum time that an increment can have. If this is exceeded, the program stops.
-INT:incrementLimit=120
+; Maximum time (in seconds) the execution of a reformulator can take in total
+INT:totalTimeLimit=120
 ; Reformulators
     ; sameoutput - Does nothing
     ; walker - Generates macros based on walks through the state space

--- a/settingsLab.ini
+++ b/settingsLab.ini
@@ -43,6 +43,7 @@ STRING:levelReductionTypes=Division
 
 ; == Entanglement Evaluator Settings ==
 DOUBLE:minimumQualityPercent=0.50
+INT:maxCandidates=100
 ; EntanglerLengthModifier - What modifier to give to the Quality of occurance length
     ; none - 1
     ; default - Length / MaxLength

--- a/settingsLab.ini
+++ b/settingsLab.ini
@@ -13,8 +13,8 @@ PATH:validatorpath=../../P7Requirements/downward/VAL/validate
 INT:startIncrement=1
 ; incrementModifier - By how much the previous increment time limit should be multiplied with
 INT:incrementModifier=3
-; Maximum time that an increment can have. If this is exceeded, the program stops.
-INT:incrementLimit=120
+; Maximum time (in seconds) the execution of a reformulator can take in total
+INT:totalTimeLimit=120
 ; Reformulators
     ; sameoutput - Does nothing
     ; walker - Generates macros based on walks through the state space

--- a/settingsLabMultiple.ini
+++ b/settingsLabMultiple.ini
@@ -43,6 +43,7 @@ STRING:levelReductionTypes=Division
 
 ; == Entanglement Evaluator Settings ==
 DOUBLE:minimumQualityPercent=0.50
+INT:maxCandidates=100
 ; EntanglerLengthModifier - What modifier to give to the Quality of occurance length
     ; none - 1
     ; default - Length / MaxLength

--- a/settingsLabMultiple.ini
+++ b/settingsLabMultiple.ini
@@ -13,8 +13,8 @@ PATH:validatorpath=../../P7Requirements/downward/VAL/validate
 INT:startIncrement=1
 ; incrementModifier - By how much the previous increment time limit should be multiplied with
 INT:incrementModifier=3
-; Maximum time that an increment can have. If this is exceeded, the program stops.
-INT:incrementLimit=120
+; Maximum time (in seconds) the execution of a reformulator can take in total
+INT:totalTimeLimit=120
 ; Reformulators
     ; sameoutput - Does nothing
     ; walker - Generates macros based on walks through the state space

--- a/settingsStress.ini
+++ b/settingsStress.ini
@@ -44,6 +44,7 @@ STRING:levelReductionTypes=Division
 
 ; == Entanglement Evaluator Settings ==
 DOUBLE:minimumQualityPercent=0.50
+INT:maxCandidates=100
 ; EntanglerLengthModifier - What modifier to give to the Quality of occurance length
     ; none - 1
     ; default - Length / MaxLength

--- a/settingsStress.ini
+++ b/settingsStress.ini
@@ -14,8 +14,8 @@ PATH:validatorpath=../../P7Requirements/downward/VAL/validate
 INT:startIncrement=1
 ; incrementModifier - By how much the previous increment time limit should be multiplied with
 INT:incrementModifier=3
-; Maximum time that an increment can have. If this is exceeded, the program stops.
-INT:incrementLimit=120
+; Maximum time (in seconds) the execution of a reformulator can take in total
+INT:totalTimeLimit=120
 ; Reformulators
     ; sameoutput - Does nothing
     ; walker - Generates macros based on walks through the state space

--- a/src/CommonInterface/CommonInterface.cpp
+++ b/src/CommonInterface/CommonInterface.cpp
@@ -60,7 +60,7 @@ InterfaceStep<PDDLInstance*> CommonInterface::ConvertPDDLFormat(PDDLDriver* driv
 }
 
 InterfaceStep<void> CommonInterface::RunIteratively(BaseReformulator* reformulator, PDDLInstance* instance) {
-	int timeLimit = config.GetItem<int>("incrementLimit");
+	int timeLimit = config.GetItem<int>("totalTimeLimit");
 	int currentIncrementTimeLimit = config.GetItem<int>("startIncrement");
 	bool isDirect = false;
 
@@ -94,8 +94,9 @@ InterfaceStep<void> CommonInterface::RunIteratively(BaseReformulator* reformulat
 
 InterfaceStep<void> CommonInterface::RunDirect(BaseReformulator* reformulator, PDDLInstance* instance) {
 	int iterativeProcess = Report->Begin("Reformulating Directly");
+	int timeLimit = config.GetItem<int>("totalTimeLimit");
 
-	if (RunSingle(reformulator, instance, iterativeProcess, -1).RanWithoutErrors)
+	if (RunSingle(reformulator, instance, iterativeProcess, timeLimit).RanWithoutErrors)
 		return InterfaceStep<void>();
 	else
 		return InterfaceStep<void>(false);

--- a/src/DownwardRunner/DownwardRunner.cpp
+++ b/src/DownwardRunner/DownwardRunner.cpp
@@ -1,5 +1,4 @@
 #include "DownwardRunner.hh"
-
 using namespace std;
 
 void DownwardRunner::RunDownward(Config config, string reformulatedDomain, string reformulatedProblem, int timeLimit) {
@@ -8,9 +7,9 @@ void DownwardRunner::RunDownward(Config config, string reformulatedDomain, strin
 	if (timeLimit == -1)
 		timeLimit = std::numeric_limits<int>::max();
 	if (config.GetItem<string>("downwardheuristic").find("[") == std::string::npos)
-		command = path + " --search-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + "())\"" + " > " + RunnerLogName;
+		command = path + " --overall-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + "())\"" + " > " + RunnerLogName;
 	else
-		command = path + " --search-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + ")\"" + " > " + RunnerLogName;
+		command = path + " --overall-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + ")\"" + " > " + RunnerLogName;
 	system(command.c_str());
 }
 

--- a/src/DownwardRunner/DownwardRunner.cpp
+++ b/src/DownwardRunner/DownwardRunner.cpp
@@ -7,9 +7,9 @@ void DownwardRunner::RunDownward(Config config, string reformulatedDomain, strin
 	if (timeLimit == -1)
 		timeLimit = std::numeric_limits<int>::max();
 	if (config.GetItem<string>("downwardheuristic").find("[") == std::string::npos)
-		command = path + " --overall-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + "())\"" + " > " + RunnerLogName;
+		command = path + " --search-time-limit " + to_string(timeLimit) + "s --translate-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + "())\"" + " > " + RunnerLogName;
 	else
-		command = path + " --overall-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + ")\"" + " > " + RunnerLogName;
+		command = path + " --search-time-limit " + to_string(timeLimit) + "s --translate-time-limit " + to_string(timeLimit) + "s " + reformulatedDomain + " " + reformulatedProblem + " --search \"" + config.GetItem<string>("downwardsearch") + "(" + config.GetItem<string>("downwardheuristic") + ")\"" + " > " + RunnerLogName;
 	system(command.c_str());
 }
 

--- a/src/EntanglementFinder/EntanglementEvaluator.cpp
+++ b/src/EntanglementFinder/EntanglementEvaluator.cpp
@@ -3,7 +3,6 @@
 using namespace std;
 
 vector<EntanglementOccurance> EntanglementEvaluator::EvaluateAndSanitizeCandidates(unordered_map<size_t, EntanglementOccurance> candidates) {
-	vector<EntanglementOccurance> sanitizedCandidates;
 	int preCount = candidates.size();
 
 	// Setup default modifiers
@@ -18,7 +17,11 @@ vector<EntanglementOccurance> EntanglementEvaluator::EvaluateAndSanitizeCandidat
 
 	_RemovedCandidates = preCount - candidates.size();
 
-	return SortCandidates(&candidates);
+	vector<EntanglementOccurance> sanitizedCandidates = SortCandidates(&candidates);
+	if (sanitizedCandidates.size() > Data.MaxCandidates) {
+		sanitizedCandidates.erase(sanitizedCandidates.begin() + Data.MaxCandidates, sanitizedCandidates.end());
+	}
+	return sanitizedCandidates;
 }
 
 void EntanglementEvaluator::SetModifiersIfNotSet() {

--- a/src/EntanglementFinder/EntanglementEvaluator.hh
+++ b/src/EntanglementFinder/EntanglementEvaluator.hh
@@ -16,6 +16,7 @@ class EntanglementEvaluator {
 public:
 	struct RunData {
 		double MinimumQualityPercent = 0;
+		int MaxCandidates = 1;
 	};
 
 	RunData Data;

--- a/src/PDDLCodeGenerator/PDDLDomainCodeGenerator.cpp
+++ b/src/PDDLCodeGenerator/PDDLDomainCodeGenerator.cpp
@@ -60,19 +60,11 @@ string PDDLDomainCodeGenerator::GetAction(PDDLAction action) {
 	}
 	retStr += "\n";
 	retStr += GetTabs(2) + ")\n";
-	retStr += GetTabs(2) + ":precondition (";
-	if (action.preconditions.size() > 1)
-		retStr += "and\n";
-	else
-		retStr += "\n";
+	retStr += GetTabs(2) + ":precondition (and\n";
 	for (auto i : action.preconditions)
 		retStr += GetTabs(3) + GetLiteral(action, i) + "\n";
 	retStr += GetTabs(2) + ")\n";
-	retStr += GetTabs(2) + ":effect (";
-	if (action.effects.size() > 1)
-		retStr += "and\n";
-	else
-		retStr += "\n";
+	retStr += GetTabs(2) + ":effect (and\n";
 	for (auto i : action.effects)
 		retStr += GetTabs(3) + GetLiteral(action, i) + "\n";
 	retStr += GetTabs(2) + ")\n";

--- a/src/Reformulators/WalkerReformulator.cpp
+++ b/src/Reformulators/WalkerReformulator.cpp
@@ -123,6 +123,7 @@ vector<EntanglementOccurance> WalkerReformulator::FindEntanglements(vector<Path>
 	// Sanitize and remove bad candidates.
 	EntanglementEvaluator::RunData entEvaluatorData;
 	entEvaluatorData.MinimumQualityPercent = Configs->GetItem<double>("minimumQualityPercent");
+	entEvaluatorData.MaxCandidates = Configs->GetItem<int>("maxCandidates");
 
 	entanglementEvaluator = new EntanglementEvaluator(entEvaluatorData);
 	if (Configs->GetItem<string>("entanglerLengthModifier") == "lengthBias")


### PR DESCRIPTION
* Fixed an issue where the Translator of Fast Downward took longer time to execute than the time limit allowed
* Fixed an issue where the RunDirect method was not limited by the timelimit
* Fixed an issue in the PDDL Code Generator, where effects with a single fact was outputted wrong
* Added a hard limit to how many candidates we allow to make macros out of (might need to find a better solution for this)