### PR TITLE
Makes pipeline case insensitive 

### DIFF
--- a/Test/IntermediatePDDL/CMakeLists.txt
+++ b/Test/IntermediatePDDL/CMakeLists.txt
@@ -3,7 +3,8 @@ target_link_libraries(Tests-IntermediatePDDL
     PRIVATE 
         Catch2::Catch2WithMain
         IntermediatePDDL
-        PDDLParser)
+        PDDLParser
+        StringHelper)
 
 file(COPY Test/IntermediatePDDL/TestFiles DESTINATION ${CMAKE_BINARY_DIR})
 

--- a/Test/IntermediatePDDL/IntermediatePDDL.cpp
+++ b/Test/IntermediatePDDL/IntermediatePDDL.cpp
@@ -14,7 +14,7 @@ const string TAG = "IntermediatePDDL ";
 const string domainFile = "./TestFiles/gripper.pddl";
 const string exDomainName = "gripper";
 const vector<string> exDomainReq = {":strips", ":equality"};
-const vector<string> exConditions = {"ROOM", "BALL", "GRIPPER", "at-lobby", "at-ball", "free", "carry"};
+const vector<string> exConditions = {"ROOM", "BALL", "GRIPPER", "AT-LOBBY", "AT-BALL", "FREE", "CARRY"};
 const vector<string> exActions = {"move", "pick-up", "drop"};
 const vector<string> exArgs = {"?z", "?y", "?x"};
 

--- a/Test/PDDLCodeGenerator/CMakeLists.txt
+++ b/Test/PDDLCodeGenerator/CMakeLists.txt
@@ -4,7 +4,8 @@ target_link_libraries(Tests-PDDLCodeGenerator
         Catch2::Catch2WithMain
         PDDLCodeGenerator
         PDDLParser
-        IntermediatePDDL)
+        IntermediatePDDL
+        StringHelper)
 
 file(COPY Test/PDDLCodeGenerator/TestFiles DESTINATION ${CMAKE_BINARY_DIR})
 

--- a/src/IntermediatePDDL/PDDLConverter.cpp
+++ b/src/IntermediatePDDL/PDDLConverter.cpp
@@ -25,7 +25,7 @@ PDDLDomain PDDLConverter::Convert(Domain *domain) {
 
     for (int i = 0; i < domain->_predicates->size(); i++) {
         auto predicate = (*domain->_predicates)[i];
-        AddPredicate(PDDLPredicate(predicate->_name, (*predicate->_args), predicate->_args->size()));
+        AddPredicate(PDDLPredicate(StringHelper::ToUpper(predicate->_name), (*predicate->_args), predicate->_args->size()));
     }    
 
     // Get Actions
@@ -75,7 +75,7 @@ std::vector<PDDLLiteral> PDDLConverter::GetLiteralList(std::unordered_map<std::s
         for (int a = 0; a < precondition->first->_args->size(); a++)
             args.push_back(parameterIndex[(*precondition->first->_args)[a]]);
 
-        literals.push_back(PDDLLiteral(predicateMap[precondition->first->_name], args, precondition->second));
+        literals.push_back(PDDLLiteral(predicateMap[StringHelper::ToUpper(precondition->first->_name)], args, precondition->second));
     }
     return literals;
 }
@@ -110,7 +110,7 @@ std::unordered_map<unsigned int, std::unordered_set<unsigned int>> PDDLConverter
         auto fact = (*literalList)[i];
         if (fact->first->_args->size() != 1)
             continue;
-        unsigned int predicateIndex = domain->predicateMap.at(fact->first->_name);
+        unsigned int predicateIndex = domain->predicateMap.at(StringHelper::ToUpper(fact->first->_name));
         unsigned int objectIndex = objectMap->at((*fact->first->_args)[0]); 
         unaryFacts.at(predicateIndex).emplace(objectIndex);
     }
@@ -127,7 +127,7 @@ std::unordered_map<unsigned int, std::unordered_set<std::pair<unsigned int, unsi
         auto fact = (*literalList)[i];
         if (fact->first->_args->size() != 2)
             continue;
-        unsigned int predicateIndex = domain->predicateMap.at(fact->first->_name);
+        unsigned int predicateIndex = domain->predicateMap.at(StringHelper::ToUpper(fact->first->_name));
         binaryFacts.at(predicateIndex).emplace(std::make_pair(objectMap->at((*fact->first->_args)[0]), objectMap->at((*fact->first->_args)[1])));
     }
     return binaryFacts;
@@ -143,7 +143,7 @@ std::unordered_map<unsigned int, std::unordered_set<MultiFact>> PDDLConverter::G
         auto fact = (*literalList)[i];
         if (fact->first->_args->size() < 3)
             continue;
-        unsigned int predicateIndex = domain->predicateMap.at(fact->first->_name);
+        unsigned int predicateIndex = domain->predicateMap.at(StringHelper::ToUpper(fact->first->_name));
         std::vector<unsigned int> objectIndexes;
         for (int a = 0; a < fact->first->_args->size(); a++)
             objectIndexes.push_back(objectMap->at((*fact->first->_args)[a]));

--- a/src/IntermediatePDDL/PDDLConverter.hh
+++ b/src/IntermediatePDDL/PDDLConverter.hh
@@ -11,6 +11,7 @@
 #include "PDDLProblem.hh"
 #include "../PDDLParser/domain.hh"
 #include "../PDDLParser/problem.hh"
+#include "../Helpers/StringHelper.hh"
 
 class PDDLConverter {
 public:


### PR DESCRIPTION
It would seem that fast downward dont care about the casing for predicate names. So now we just turn all predicates into upper case (since some of the problem/domains have a mix)
closes #207 