### PR TITLE
Entangler runtime fix

### DIFF
--- a/baseSettings.ini
+++ b/baseSettings.ini
@@ -78,6 +78,7 @@ INT:levelReductionFactor=2
     ; Division - Level = ceil(Level / levelReductionFactor)
     ; Subtraction - Level = Level - levelReductionFactor
 STRING:levelReductionTypes=Division
+DOUBLE:reformulationTimeFraction=0.1
 
 ; == Entanglement Evaluator Settings ==
 ; minimumQualityPercent - What the minimum quality of an entanglement should be for it to be valid

--- a/src/EntanglementFinder/EntanglementFinder.cpp
+++ b/src/EntanglementFinder/EntanglementFinder.cpp
@@ -49,6 +49,9 @@ unordered_map<size_t, EntanglementOccurance> EntanglementFinder::FindEntangledCa
 		AddCandidatesIfThere(&candidates, &currentValues);
 
 		level = ReduceLevel(level);
+
+		if (_IsTimeLimitReached)
+			break;
 	}
 
 	return unordered_map<size_t, EntanglementOccurance>(candidates);
@@ -122,7 +125,23 @@ void EntanglementFinder::AddCandidatesIfThere(unordered_map<size_t, Entanglement
 		}
 		if (OnLevelIteration != nullptr)
 			OnLevelIteration(i, currentValueSize);
+		if (IsOverTimeLimit())
+			break;
 	}
 	if (OnLevelEnd != nullptr)
 		OnLevelEnd();
+}
+
+bool EntanglementFinder::IsOverTimeLimit() {
+	if (_HasTimeLimit) {
+		auto currentTime = chrono::steady_clock::now();
+		auto ellapsed = chrono::duration_cast<chrono::milliseconds>(currentTime - _StartTime).count();
+		if (ellapsed > Data.TimeLimitMs) {
+			if (OnTimeLimitReached != nullptr)
+				OnTimeLimitReached();
+			_IsTimeLimitReached = true;
+			return true;
+		}
+	}
+	return false;
 }

--- a/src/EntanglementFinder/EntanglementFinder.hh
+++ b/src/EntanglementFinder/EntanglementFinder.hh
@@ -28,6 +28,7 @@ public:
 		/// By how much the level should be reduced in each iteration.
 		/// </summary>
 		double LevelReductionFactor = 2;
+		int TimeLimitMs = 100;
 		LevelReductionTypes LevelReductionType = LevelReductionTypes::Division;
 	};
 
@@ -47,11 +48,15 @@ public:
 	std::function<const void(int level, int outOf)> OnNewLevel;
 	std::function<const void()> OnLevelEnd;
 	std::function<const void(int current, int outOf)> OnLevelIteration;
+	std::function<const void()> OnTimeLimitReached;
 
 private:
 	int _CurrentLevel;
 	int _TotalLevels;
 	unsigned int _TotalComparisons;
+	bool _HasTimeLimit = false;
+	bool _IsTimeLimitReached = false;
+	std::chrono::_V2::steady_clock::time_point _StartTime;
 
 	/// <summary>
 	/// Validate the input data
@@ -65,6 +70,10 @@ private:
 	/// Based on the values generated in the "GenerateActionSet" method
 	/// </summary>
 	void AddCandidatesIfThere(std::unordered_map<size_t, EntanglementOccurance>* candidates, std::vector<std::pair<std::pair<size_t, int>, std::vector<PDDLActionInstance*>>>* currentValues);
+	/// <summary>
+	/// Returns true if the time limit have been exceeded
+	/// </summary>
+	bool IsOverTimeLimit();
 	/// <summary>
 	/// Reduce the current level
 	/// </summary>

--- a/src/Reformulators/Walkers/BaseWalkerReformulator.cpp
+++ b/src/Reformulators/Walkers/BaseWalkerReformulator.cpp
@@ -214,7 +214,6 @@ void BaseWalkerReformulator::PrintEntanglerDebugData(double ellapsed, std::vecto
 	ConsoleHelper::PrintDebugInfo("[Entanglement Finder] Total Levels:              " + std::to_string(entanglementFinder->TotalLevels()), debugIndent);
 	ConsoleHelper::PrintDebugInfo("[Entanglement Finder] Total Candidates:          " + std::to_string(entanglementEvaluator->RemovedCandidates() + candidates->size()), debugIndent);
 	ConsoleHelper::PrintDebugInfo("[Entanglement Finder] Path Data:                 " + std::to_string(paths.size()) + " paths with " + std::to_string(totalActions) + " steps in total", debugIndent);
-	ConsoleHelper::PrintDebugInfo("[Entanglement Evaluator] Total evaluation time:  " + std::to_string(ellapsed) + "ms", debugIndent);
 	ConsoleHelper::PrintDebugInfo("[Entanglement Evaluator] Total Candidates:       " + std::to_string(candidates->size()) + " (" + std::to_string(entanglementEvaluator->RemovedCandidates()) + " removed)", debugIndent);
 }
 

--- a/src/Reformulators/Walkers/BaseWalkerReformulator.cpp
+++ b/src/Reformulators/Walkers/BaseWalkerReformulator.cpp
@@ -42,6 +42,7 @@ EntanglementFinder BaseWalkerReformulator::GetEntanglementFinder(bool debugMode)
 	runData.LevelReductionFactor = Configs->GetItem<int>("levelReductionFactor");
 	runData.SearchCeiling = Configs->GetItem<int>("searchCeiling");
 	runData.SearchFloor = Configs->GetItem<int>("searchFloor");
+	runData.TimeLimitMs = TimeLimit * Configs->GetItem<double>("reformulationTimeFraction");
 	if (Configs->GetItem<std::string>("levelReductionTypes") == "Division")
 		runData.LevelReductionType = EntanglementFinder::RunData::Division;
 	if (Configs->GetItem<std::string>("levelReductionTypes") == "Subtraction")
@@ -59,6 +60,9 @@ EntanglementFinder BaseWalkerReformulator::GetEntanglementFinder(bool debugMode)
 		};
 		ef.OnLevelEnd = [&]() {
 			bar->End();
+		};
+		ef.OnTimeLimitReached = [&]() {
+			ConsoleHelper::PrintDebugWarning("[Entanglement Finder] Time limit reached!", debugIndent);
 		};
 	}
 

--- a/src/Reformulators/Walkers/GreedyResumeWalkerReformulator.cpp
+++ b/src/Reformulators/Walkers/GreedyResumeWalkerReformulator.cpp
@@ -2,7 +2,7 @@
 
 std::vector<Path> GreedyResumeWalkerReformulator::PerformWalk(PDDLInstance *instance, bool debugMode) {
     auto walkerHeuistic = Configs->GetItem<std::string>("walkerHeuristic");
-    auto walker = WalkerBuilder::BuildWalker("walkerGreedyResume", TimeLimit, walkerHeuistic, instance);
+    auto walker = WalkerBuilder::BuildWalker("walkerGreedyResume", TimeLimit * (1 - Configs->GetItem<double>("reformulationTimeFraction")), walkerHeuistic, instance);
         if (debugMode)
             SetupWalkerDebugInfo(walker);
     return walker->Walk();

--- a/src/Reformulators/Walkers/GreedyWalkerReformulator.cpp
+++ b/src/Reformulators/Walkers/GreedyWalkerReformulator.cpp
@@ -2,7 +2,7 @@
 
 std::vector<Path> GreedyWalkerReformulator::PerformWalk(PDDLInstance *instance, bool debugMode) {
     auto walkerHeuistic = Configs->GetItem<std::string>("walkerHeuristic");
-    auto walker = WalkerBuilder::BuildWalker("walkerGreedy", TimeLimit, walkerHeuistic, instance);
+    auto walker = WalkerBuilder::BuildWalker("walkerGreedy", TimeLimit * (1 - Configs->GetItem<double>("reformulationTimeFraction")), walkerHeuistic, instance);
         if (debugMode)
             SetupWalkerDebugInfo(walker);
     return walker->Walk();

--- a/src/Reformulators/Walkers/QueueWalkerReformulator.cpp
+++ b/src/Reformulators/Walkers/QueueWalkerReformulator.cpp
@@ -2,7 +2,7 @@
 
 std::vector<Path> QueueWalkerReformulator::PerformWalk(PDDLInstance *instance, bool debugMode) {
     auto walkerHeuistic = Configs->GetItem<std::string>("walkerHeuristic");
-    auto walker = WalkerBuilder::BuildWalker("walkerQueue", TimeLimit, walkerHeuistic, instance);
+    auto walker = WalkerBuilder::BuildWalker("walkerQueue", TimeLimit * (1 - Configs->GetItem<double>("reformulationTimeFraction")), walkerHeuistic, instance);
         if (debugMode)
             SetupWalkerDebugInfo(walker);
     return walker->Walk();


### PR DESCRIPTION
Set the entanglement finding to be allowed to maximum run within a fraction of the total reformulation time (became a problem in very large benchmark sets.)
closes #251 